### PR TITLE
feat: add real number support in parser and arithmetic operations

### DIFF
--- a/src/main/java/calculator/RealValue.java
+++ b/src/main/java/calculator/RealValue.java
@@ -57,28 +57,28 @@ public class RealValue implements NumberValue {
 
     @Override
     public NumberValue add(NumberValue other) {
-        RealValue o = (RealValue) other;
+        RealValue o = toReal(other);
         if (isSpecial() || o.isSpecial()) return handleSpecialAdd(o);
         return new RealValue(value.add(o.value), precision);
     }
 
     @Override
     public NumberValue sub(NumberValue other) {
-        RealValue o = (RealValue) other;
+        RealValue o = toReal(other);
         if (isSpecial() || o.isSpecial()) return handleSpecialSub(o);
         return new RealValue(value.subtract(o.value), precision);
     }
 
     @Override
     public NumberValue mul(NumberValue other) {
-        RealValue o = (RealValue) other;
+        RealValue o = toReal(other);
         if (isSpecial() || o.isSpecial()) return handleSpecialMul(o);
         return new RealValue(value.multiply(o.value, precision), precision);
     }
 
     @Override
     public NumberValue div(NumberValue other) {
-        RealValue o = (RealValue) other;
+        RealValue o = toReal(other);
         if (isSpecial() || o.isSpecial()) return handleSpecialDiv(o);
         if (o.value.compareTo(BigDecimal.ZERO) == 0) {
             // Comme en réel: 1/0 = +Inf, -1/0 = -Inf, 0/0 = NaN
@@ -155,5 +155,12 @@ public class RealValue implements NumberValue {
     public int hashCode() {
         if (isSpecial()) return specialValue.hashCode();
         return value.stripTrailingZeros().hashCode();
+    }
+
+    private RealValue toReal(NumberValue other) {
+        if (other instanceof RealValue) return (RealValue) other;
+        if (other instanceof IntegerValue)
+            return new RealValue(((IntegerValue) other).getValue());
+        throw new IllegalArgumentException("Cannot convert " + other.getClass() + " to RealValue");
     }
 }

--- a/src/main/java/calculator/parser/ExpressionParser.java
+++ b/src/main/java/calculator/parser/ExpressionParser.java
@@ -21,7 +21,11 @@ public class ExpressionParser {
         if (pos == -1) {
             // Pas d'opérateur = c'est un nombre
             try {
-                return new MyNumber(Integer.parseInt(expression));
+                if (expression.contains(".")) {
+                    return new MyNumber(new RealValue(Double.parseDouble(expression)));
+                } else {
+                    return new MyNumber(Integer.parseInt(expression));
+                }
             } catch (NumberFormatException e) {
                 throw new Exception("Invalid number: " + expression);
             }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -103,8 +103,8 @@ const app = (() => {
     /** Add the current input value to the numbers list. */
     function addNumber() {
         const raw = numberInput.value.trim();
-        if (raw === '' || !/^-?\d+$/.test(raw)) {
-            showError('Please enter a valid integer (no decimals).');
+        if (raw === '' || !/^-?\d+(\.\d+)?$/.test(raw)) {
+            showError('Please enter a valid number.');
             return;
         }
 
@@ -116,7 +116,7 @@ const app = (() => {
             operators.push(pendingOperation);
         }
 
-        numbers.push(parseInt(raw, 10));
+        numbers.push(parseFloat(raw));
         pendingOperation = null;
         highlightOp(null);
         numberInput.value = '';


### PR DESCRIPTION
## What
Support real numbers (e.g. 2.1, 3.14) in the calculator.

## Changes
- `app.js`: fix regex and replace parseInt with parseFloat to allow decimal input
- `ExpressionParser.java`: detect decimal numbers and parse them as RealValue
- `RealValue.java`: add toReal() helper to convert IntegerValue before arithmetic operations

## Why
Previously, entering 2.1 was blocked by frontend validation, and even if it passed,
the backend would throw a cast error when mixing RealValue and IntegerValue in operations.

## Test
- 2.1 + 2 = 4.1
- 3.14 * 2 = 6.28 